### PR TITLE
Fix: 日本語著者名の後にピリオドが付くバグを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tmp/
 
 # macOS
 .DS_Store
+
+.claude/
+.serena/

--- a/README.md
+++ b/README.md
@@ -57,23 +57,38 @@ make help
 `cite.yaml`に参考文献を追加：
 
 ```yaml
-- id: author2024
+# 英語著者名: family/given を使用（イニシャルに自動変換される）
+- id: smith2024
   type: article-journal
   author:
-    - family: 著者姓
-      given: 著者名
-  title: 論文タイトル
-  container-title: ジャーナル名
+    - family: Smith
+      given: John
+  title: "Paper Title"
+  container-title: Journal Name
   volume: 1
-  issue: 1
+  page: 1-10
+  issued:
+    year: 2024
+
+# 日本語著者名: literal を使用（フルネームがそのまま出力される）
+- id: yamada2024
+  type: article-journal
+  author:
+    - literal: 山田太郎
+  title: "論文タイトル"
+  container-title: 情報処理学会論文誌
+  volume: 1
   page: 1-10
   issued:
     year: 2024
 ```
 
+> **注意**: 日本語の著者名には `literal` フィールドを使用してください。`family`/`given` を使うと名前がイニシャルに省略されピリオドが付いてしまいます。
+
 本文中での引用：
 ```markdown
-既存研究では[@author2024]...
+既存研究では[@smith2024]...
+複数の文献[@smith2024; @yamada2024]では...
 ```
 
 ## 必要な環境

--- a/b-thesis-template.md
+++ b/b-thesis-template.md
@@ -203,6 +203,7 @@ make INPUT=paper.md
 
 ```yaml
 references:
+  # 英語著者名: family/given を使用
   - id: example2024
     type: article-journal
     author:
@@ -214,9 +215,21 @@ references:
     page: 100-120
     issued:
       year: 2024
+
+  # 日本語著者名: literal を使用
+  - id: yamada2024
+    type: article-journal
+    author:
+      - literal: 山田太郎
+    title: "日本語論文のタイトル"
+    container-title: 情報処理学会論文誌
+    volume: 65
+    page: 1-10
+    issued:
+      year: 2024
 ```
 
-`id`フィールドが引用キーとなり、本文中で`[@example2024]`のように参照する。文献の引用は以下の形式で記述する。
+`id`フィールドが引用キーとなり、本文中で`[@example2024]`のように参照する。日本語の著者名は `family`/`given` ではなく `literal` フィールドを使用すること。`family`/`given` を使うと、名前がイニシャルに省略されピリオドが付いてしまう。例えば、和文雑誌の文献[@arakane2005]は `literal` フィールドで著者名を記述している。文献の引用は以下の形式で記述する。
 
 ```markdown
 先行研究[@example2024]では...

--- a/cite.yaml
+++ b/cite.yaml
@@ -1,8 +1,30 @@
 # 参考文献データベース
 # CSL-YAML形式で記述
 # 詳細: https://pandoc.org/MANUAL.html#citations
+#
+# 著者名の記述方法:
+#   英語名 → family/given を使用（イニシャルに自動変換される）
+#     - family: Smith
+#       given: John
+#   日本語名 → literal を使用（フルネームがそのまま出力される）
+#     - literal: 山田太郎
 
 references:
+  # 例: 和文雑誌（日本語著者名は literal を使用）
+  - id: arakane2005
+    type: article-journal
+    author:
+      - literal: 荒金陽助
+      - literal: 下川清志
+      - literal: 金井敦
+    title: "音声対話システムにおけるスケーラビリティ評価モデルの検討"
+    container-title: 情報処理学会論文誌
+    volume: 46
+    issue: 9
+    page: 2269-2278
+    issued:
+      year: 2005
+
   # 例: ジャーナル論文
   - id: example2024
     type: article-journal

--- a/cite.yaml
+++ b/cite.yaml
@@ -16,7 +16,7 @@ references:
     author:
       - literal: 荒金陽助
       - literal: 下川清志
-      - literal: 金井敦
+      - literal: "金井　敦"
     title: "音声対話システムにおけるスケーラビリティ評価モデルの検討"
     container-title: 情報処理学会論文誌
     volume: 46


### PR DESCRIPTION
## Summary
- CSLの`initialize-with=". "`属性により、日本語著者名がイニシャル化されピリオドが付く問題に対応
- `cite.yaml`で日本語著者名に`literal`フィールドを使用するルールを導入
- README.md、b-thesis-template.md、cite.yamlに記述例とガイダンスを追加

## 変更内容
- **cite.yaml**: 冒頭に著者名の記述ルールをコメント追加、和文雑誌の記述例(`literal`使用)を追加
- **b-thesis-template.md**: 引用と参考文献セクションに日本語著者名の`literal`記述例と注意書きを追加
- **README.md**: 参考文献の管理セクションに英語名・日本語名の両方の例と注意書きを追加

## Test plan
- [x] `make`でビルドし、参考文献リストの日本語著者名にピリオドが付かないことを確認
- [x] 英語著者名が従来通りイニシャル化されることを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)